### PR TITLE
Upgrade login example to express 4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Node.js
 node_modules/*
 npm-debug.log
+examples/login/node_modules/*

--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -2,9 +2,15 @@
   "name": "passport-goodreads-examples-login",
   "version": "0.0.0",
   "dependencies": {
-    "express": ">= 0.0.0",
+    "body-parser": "1.14.2",
+    "cookie-parser": "1.4.0",
     "ejs": ">= 0.0.0",
+    "express": "4.13.3",
+    "express-session": "1.12.1",
+    "method-override": "2.3.5",
+    "morgan": "1.6.1",
     "passport": ">= 0.0.0",
-    "passport-goodreads": ">= 0.0.0"
+    "passport-goodreads": ">= 0.0.0",
+    "serve-static": "1.10.0"
   }
 }


### PR DESCRIPTION
I've upgraded example to work with express 4.x which is now installed by default with config from `examples/login/package.json`. Other possibility is to fix version of express to 3.x in package.json.
